### PR TITLE
Downgrade the PHP version requirement from 8.0 to 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=8.0",
+        "php": ">=7.4",
         "laravel/nova": "^4.0"
     },
     "repositories": [


### PR DESCRIPTION
Hey @stepanenko3, thanks for putting this repo together.

Small edit: you have PHP 8.0 listed as the minimum version requirement, but I have confirmed that 7.4 works just fine with the code base. 

Please consider merging this PR, so us sad folks stuck on 7.4 for the time being can enjoy the fruits of your labor.

Thanks  👍