### PR TITLE
Move Inertia route closure to controller

### DIFF
--- a/routes/inertia.php
+++ b/routes/inertia.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use Laravel\Nova\Http\Requests\NovaRequest;
+use Stepanenko3\NovaCommandRunner\Http\Controllers\CommandsController;
 
 /*
 |--------------------------------------------------------------------------
@@ -14,6 +14,4 @@ use Laravel\Nova\Http\Requests\NovaRequest;
 |
 */
 
-Route::get('/', function (NovaRequest $request) {
-    return inertia('NovaCommandRunner');
-});
+Route::get('/', [CommandsController::class, 'show']);

--- a/src/Http/Controllers/CommandsController.php
+++ b/src/Http/Controllers/CommandsController.php
@@ -14,6 +14,11 @@ use Illuminate\Http\Request;
  */
 class CommandsController
 {
+    public function show()
+    {
+        return inertia('NovaCommandRunner');
+    }
+
     /**
      * @return array
      */


### PR DESCRIPTION
This PR will prevent the throwing of `Laravel\SerializableClosure\Exceptions\InvalidSignatureException` when an application is running on Laravel Vapor. Solves #5.

I tested this in our staging environment with a monkey patch and can confirm it works. ALso, in debugging this, I noticed the same error on a few of your other packages on [nova packages](https://novapackages.com/collaborators/stepanenko3).