### PR TITLE
feat: add RunsArtisan Trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## [4.4.0](#)
+- Added `Stepanenko3\NovaCommandRunner\Traits\RunsArtisan`
+- Update `run_by` assignment to use the `getArtisanRunByName` method
+
 ## [4.1.0](#)
 - `Stepanenko3\NovaCommandRunner\CommandRunner` migrate to `Stepanenko3\NovaCommandRunner\CommandRunnerTool`
 

--- a/src/Dto/RunDto.php
+++ b/src/Dto/RunDto.php
@@ -24,7 +24,11 @@ class RunDto
 
     public function __construct()
     {
-        $this->run_by = auth()->check() ? auth()->user()->name : '';
+        if (auth()->check() && method_exists(auth()->user(), 'getArtisanRunByName')) {
+            $this->run_by = auth()->user()->getArtisanRunByName();
+        } else {
+            $this->run_by = __('unknown');
+        }
         $this->id = uniqid();
     }
 

--- a/src/Traits/RunsArtisan.php
+++ b/src/Traits/RunsArtisan.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Stepanenko3\NovaCommandRunner\Traits;
+
+trait RunsArtisan
+{
+    /**
+     * The name of the user running an Artisan command.
+     *
+     * @return null|string
+     */
+    public function getArtisanRunByName(): ?string
+    {
+        return $this->name;
+    }
+}


### PR DESCRIPTION
- Added RunsArtisan trait
- Update `run_by` assignment to use `getArtisanRunByName` method

Fixes #20 and #36. I suggest bumping the version to 4.4.0, but let me know if you'd like to release it as a patch instead, so I can update the changelog accordingly.