### PR TITLE
Update laravel/nova dependency to either 4x or 5x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "license": "MIT",
     "require": {
         "php": ">=7.4",
-        "laravel/nova": "^5.0",
+        "laravel/nova": "^5.0 || ^4.0",
         "stepanenko3/laravel-helpers": "^1.3.2"
     },
     "autoload": {


### PR DESCRIPTION
Allow newer versions of command-runner to use laravel/nova 4.xx OR 5.xx while other dependencies are updated as well. 