### PR TITLE
Escape command variable values

### DIFF
--- a/src/Dto/CommandDto.php
+++ b/src/Dto/CommandDto.php
@@ -37,14 +37,19 @@ class CommandDto
         if (is_array($variables)) {
             foreach ($variables as $variable) {
                 if (isset($variable['label'], $variable['value'])) {
+                    $value = $variable['value'];
+                    if (!empty($value) && (str_contains($value, '"') || str_contains($value, ' '))) {
+                        $value = '"' . str_replace('"', '\"', $value) . '"';
+                    }
+
                     if (str_contains($variable['label'], '--')) {
                         $variableName = explode('=', $variable['label'])[0];
                         $command->setParsedCommand(
-                            str_replace('{' . $variable['label'] . '}', $variableName . '=' . $variable['value'], $command->getParsedCommand())
+                            str_replace('{' . $variable['label'] . '}', $variableName . '=' . $value, $command->getParsedCommand())
                         );
                     } else {
                         $command->setParsedCommand(
-                            str_replace('{' . $variable['label'] . '}', $variable['value'], $command->getParsedCommand())
+                            str_replace('{' . $variable['label'] . '}', $value, $command->getParsedCommand())
                         );
                     }
                 }


### PR DESCRIPTION
Parameter values containing spaces or quotes should be escaped and surrounded by quotes in order to be executable by artisan. There might be other edge cases, but I think this is already a good start for general purposes.